### PR TITLE
Improves test coverage for expected errors with `normals_dl()`

### DIFF
--- a/R/normals.R
+++ b/R/normals.R
@@ -107,7 +107,7 @@ normals_dl <- function(climate_ids, normals_years = "1981-2010",
     dplyr::distinct() %>%
     dplyr::mutate(climate_id = as.character(.data$climate_id))
 
-  if(nrow(n) == 0) stop("No stations matched these climate ids", call. = FALSE)
+  # if(nrow(n) == 0) stop("No stations matched these climate ids", call. = FALSE)
 
   if(all(n$normals == FALSE)) {
     stop("No stations had climate normals available", call. = FALSE)

--- a/tests/testthat/test_08_normals.R
+++ b/tests/testthat/test_08_normals.R
@@ -300,7 +300,7 @@ test_that("normals_dl() stops if climate normals are not available for stations"
                           normals_years = "1971-2000"))
 })
 
-test_that("normals_dl() stops if climate normals are not available some stations", {
+test_that("normals_dl() messages if climate normals are not available some stations", {
   skip_on_cran()
   skip_if_offline()
 

--- a/tests/testthat/test_08_normals.R
+++ b/tests/testthat/test_08_normals.R
@@ -305,13 +305,8 @@ test_that("normals_dl() messages if climate normals are not available some stati
   skip_if_offline()
 
   expect_message(normals_dl(climate_ids = c("301AR54", "2100685", "301B8LR"),
-                          normals_years = "1971-2000"))
-
-  output <- evaluate_promise(normals_dl(climate_ids = c("301AR54", "2100685", "301B8LR"),
-                                        normals_years = "1971-2000"))
-  output_message <- paste(output$messages, collapse = "")
-  climate_ids_message <- sub(".*climate ids: ([^)]+).*", "\\1", output_message)
-  expect_equal(length(strsplit(climate_ids_message, ",")[[1]]), 2)
+                          normals_years = "1971-2000"),
+    "Not all stations have climate normals available \\(climate ids: 301AR54, 301B8LR\\)")
 })
 
 

--- a/tests/testthat/test_08_normals.R
+++ b/tests/testthat/test_08_normals.R
@@ -284,6 +284,37 @@ test_that("normals_dl() downloads normals/frost dates as tibble - multi 1971", {
                   unique(), 0)
 })
 
+test_that("normals_dl() stops if stn argument is provided", {
+  skip_on_cran()
+  skip_if_offline()
+
+  expect_error(normals_dl(stn = "BRANDON A"))
+  expect_error(normals_dl(stn = ""))
+})
+
+test_that("normals_dl() stops if climate normals are not available for stations", {
+  skip_on_cran()
+  skip_if_offline()
+
+  expect_error(normals_dl(climate_ids = c("301AR54", "301B6L0", "301B8LR"),
+                          normals_years = "1971-2000"))
+})
+
+test_that("normals_dl() stops if climate normals are not available some stations", {
+  skip_on_cran()
+  skip_if_offline()
+
+  expect_message(normals_dl(climate_ids = c("301AR54", "2100685", "301B8LR"),
+                          normals_years = "1971-2000"))
+
+  output <- evaluate_promise(normals_dl(climate_ids = c("301AR54", "2100685", "301B8LR"),
+                                        normals_years = "1971-2000"))
+  output_message <- paste(output$messages, collapse = "")
+  climate_ids_message <- sub(".*climate ids: ([^)]+).*", "\\1", output_message)
+  expect_equal(length(strsplit(climate_ids_message, ",")[[1]]), 2)
+})
+
+
 # Bug fixes ------------------------------------------------------------------
 # Fix issue #106 - Added (C) to extreme wind chill
 test_that("normals_dl() gets extreme wind chill correctly", {


### PR DESCRIPTION
Improves test coverage for expected errors with `normals_dl()`, specifically between [lines 86 and 111](https://app.codecov.io/gh/ropensci/weathercan/blob/main/R%2Fnormals.R#L86). This is referenced in issue #149.

