### PR TITLE
Added more tests to increase coverage for weather.R

### DIFF
--- a/R/weather.R
+++ b/R/weather.R
@@ -194,7 +194,11 @@ weather_dl <- function(station_ids,
       msg.start <- start
     }
 
-    if(is.null(end)) s.end <- Sys.Date() else s.end <- as.Date(end)
+    if(is.null(end)) {
+        s.end <- Sys.Date()
+    } else {
+        s.end <- as.Date(end)
+    }
     msg.end <- as.character(s.end)
 
     dates <- lubridate::interval(s.start, s.end)
@@ -331,7 +335,11 @@ weather_dl <- function(station_ids,
   }
 
   if(length(end_dates) > 0 & !quiet) {
-    if(all(station_ids %in% missing)) type <- "all" else type <- "some"
+    if(all(station_ids %in% missing)) {
+        type <- "all"
+    } else {
+        type <- "some"
+    }
 
     message(paste0("The end dates (", msg.end, ") are earlier than the ",
                    "start dates (", msg.start, ") for ", type, " stations (",

--- a/tests/testthat/test_07_weather_args.R
+++ b/tests/testthat/test_07_weather_args.R
@@ -133,7 +133,7 @@ test_that("weather_dl() (invalid end day) returns error when end is not a valid 
 })
 
 
-test_that("weather_dl() (invalid end string) verifies error return when start is not a valid date string", {
+test_that("weather_dl() (invalid end string) verifies error return when end is not a valid date string", {
   skip_on_cran()
   vcr::use_cassette("weather_month_5401", {
     expect_error(weather_dl(station_ids = 5401,

--- a/tests/testthat/test_07_weather_args.R
+++ b/tests/testthat/test_07_weather_args.R
@@ -95,3 +95,64 @@ test_that("weather_dl() month string_as = NULL", {
   })
 
 })
+
+
+test_that("weather_dl() (invalid start day) returns error when start is not a valid date day", {
+  skip_on_cran()
+
+  vcr::use_cassette("weather_month_5401", {
+    expect_error(weather_dl(station_ids = 5401,
+                                  start = "2017-01-99",
+                                  end = "2017-05-01",
+                                  interval = "month", format = FALSE),
+      "'start' and 'end' must be either a standard date format ")
+  })
+})
+
+test_that("weather_dl() (invalid start string) returns error when start is not a valid date string", {
+  skip_on_cran()
+
+  vcr::use_cassette("weather_month_5401", {
+    expect_error(weather_dl(station_ids = 5401,
+                                  start = "2017-01-NN",
+                                  end = "2017-05-01",
+                                  interval = "month", format = FALSE),
+      "'start' and 'end' must be either a standard date format ")
+  })
+})
+
+test_that("weather_dl() (invalid end day) returns error when start is not a valid date day", {
+  skip_on_cran()
+  vcr::use_cassette("weather_month_5401", {
+    expect_error(weather_dl(station_ids = 5401,
+                                  start = "2017-01-01",
+                                  end = "2017-04-99",
+                                  interval = "month", format = FALSE),
+      "'start' and 'end' must be either a standard date format ")
+  })
+})
+
+
+test_that("weather_dl() (invalid end string) verifies error return when start is not a valid date string", {
+  skip_on_cran()
+  vcr::use_cassette("weather_month_5401", {
+    expect_error(weather_dl(station_ids = 5401,
+                                  start = "2017-01-01",
+                                  end = "2017-04-NN",
+                                  interval = "month", format = FALSE),
+      "'start' and 'end' must be either a standard date format ")
+  })
+})
+
+
+test_that("weather_dl() (invalid stn) verifies error return when defunct stn", {
+  skip_on_cran()
+  vcr::use_cassette("weather_month_5401", {
+    expect_error(weather_dl(station_ids = 5401,
+                                  start = "2017-01-01",
+                                  end = "2017-05-01",
+                                  stn = "invalid defunct",
+                                  interval = "month", format = FALSE),
+      "`stn` is defunct, to use an updated stations data frame use ")
+  })
+})

--- a/tests/testthat/test_07_weather_args.R
+++ b/tests/testthat/test_07_weather_args.R
@@ -121,7 +121,7 @@ test_that("weather_dl() (invalid start string) returns error when start is not a
   })
 })
 
-test_that("weather_dl() (invalid end day) returns error when start is not a valid date day", {
+test_that("weather_dl() (invalid end day) returns error when end is not a valid date day", {
   skip_on_cran()
   vcr::use_cassette("weather_month_5401", {
     expect_error(weather_dl(station_ids = 5401,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added 5 more tests to increase coverage for weather.R. Covered invalid start date, invalid end date, and defunct stn arg.

## Related Issue
#149

## Example


## Best Practices
<!--- Did you remember to include documentation, examples andtests? Unless you're just changing
grammar, please include new tests for your change -->
The following have been updated or added as needed:
[ ] Documentation
[ ] Examples in documentation
[ ] Vignettes
[x] `testthat` Tests
