### PR TITLE
Unit tests for stations_search()

### DIFF
--- a/tests/testthat/test_03_station_dl.R
+++ b/tests/testthat/test_03_station_dl.R
@@ -271,4 +271,13 @@ test_that("stations_search returns normals only", {
 
   expect_message(s3 <- stations_search("Brandon", normals_years = "1991-2020"),
                  "be aware that they are not yet available")
+
+  expect_error(
+    stations_search(name = "Ottawa", normals_years = "invalid input"),
+    "`normals_years` must either be `NULL`"
+  )
+  expect_no_error(stations_search(name = "Ottawa", normals_years = NULL))
+  expect_no_error(stations_search(name = "Ottawa", normals_years = "current"))
+
+
 })


### PR DESCRIPTION
Partially addresses request for some unit tests in issue #161

Created unit test for the normals_years variable in the stations_search() function

## Description
Created tests checking if the input in normals_years is valid

## Related Issue
Partially addresses the request for unit tests in #161

## Example
NA

## Best Practices
The following have been updated or added as needed:
[NA] Documentation
[NA] Examples in documentation
[NA] Vignettes
[Y] `testthat` Tests
