### PR TITLE
Add tests for interval validation

### DIFF
--- a/tests/testthat/test-interval-validation.R
+++ b/tests/testthat/test-interval-validation.R
@@ -1,0 +1,19 @@
+test_that("stations_search rejects invalid interval", {
+  expect_error(
+    stations_search(interval = "year")
+  )
+
+  expect_error(
+    stations_search(interval = c("day", "month"))
+  )
+})
+
+test_that("weather_interp rejects invalid interval", {
+  expect_error(
+    weather_interp(interval = "year")
+  )
+
+  expect_error(
+    weather_interp(interval = c("day", "month"))
+  )
+})


### PR DESCRIPTION
Description
This pull request adds a new test file called tests/testthat/test-interval-validation.R. The file checks the interval argument. The tests make sure that stations_search() and weather_interp() give errors if the interval value is not supported. They check that using interval = "year" or interval = c("day", "month") causes errors. Only "hour", "day", and "month" are allowed.

Related Issue
This work adds tests for wrong interval values in stations_search() and weather_interp(). It supports the discussion in issue #166. It does not change how the functions work. It only adds tests to cover the current checks.

Example
For example, the new tests expect:

stations_search(interval = "year") and stations_search(interval = c("day", "month")) both give an error that the interval is invalid.
weather_interp(interval = "year") and weather_interp(interval = c("day", "month")) also give errors for wrong interval values.
These tests are in the new testthat file. They run with the other tests automatically.

Best Practices
We updated or added the following as needed:

[ ] Documentation

[ ] Examples in documentation

[ ] Vignettes

[x] testthat Tests
